### PR TITLE
Fix NullReferenceException in getClassTraitText for players with no extraTraits

### DIFF
--- a/traitacquirer/traitacquirerModSystem.cs
+++ b/traitacquirer/traitacquirerModSystem.cs
@@ -332,19 +332,22 @@ namespace traitacquirermoddedclasses
 
             string[] extraTraits = capi.World.Player.Entity.WatchedAttributes.GetStringArray("extraTraits");
             // Filter out any extra traits that are not defined in the loaded traits
-            List<string> extraTraitsRemove = new List<string>();
-            foreach (string extratrait in extraTraits)
+            if (extraTraits != null)
             {
-                if (!TraitsByCode.ContainsKey(extratrait))
+                List<string> extraTraitsRemove = new List<string>();
+                foreach (string extratrait in extraTraits)
                 {
-                    capi.World.Logger.Warning($"Player has an extra trait '{extratrait}' that is not defined in the loaded traits.");
-                    extraTraitsRemove.Add(extratrait);
+                    if (!TraitsByCode.ContainsKey(extratrait))
+                    {
+                        capi.World.Logger.Warning($"Player has an extra trait '{extratrait}' that is not defined in the loaded traits.");
+                        extraTraitsRemove.Add(extratrait);
+                    }
+
                 }
-                
-            }
-            foreach (string extratrait in extraTraitsRemove)
-            {
-                extraTraits = extraTraits.Remove(extratrait);
+                foreach (string extratrait in extraTraitsRemove)
+                {
+                    extraTraits = extraTraits.Remove(extratrait);
+                }
             }
             IOrderedEnumerable<string> extratraits = Enumerable.Empty<string>().OrderBy(x => 1); ;
             if (extraTraits != null)


### PR DESCRIPTION
## Bug

Opening the character sheet's Traits tab crashes the client with:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at traitacquirermoddedclasses.traitacquirerModSystem.getClassTraitText()
   at traitacquirermoddedclasses.traitacquirerModSystem.composeTraitsTab(GuiComposer compo)
```

## Root cause

`274f734` ("ClassTraitText should automatically exclude any traits it does not have data for") added a cleanup loop that iterates `extraTraits` directly:

```csharp
string[] extraTraits = capi.World.Player.Entity.WatchedAttributes.GetStringArray("extraTraits");
// Filter out any extra traits that are not defined in the loaded traits
List<string> extraTraitsRemove = new List<string>();
foreach (string extratrait in extraTraits)
```

`GetStringArray("extraTraits")` returns `null` when the player has never acquired an extra trait (e.g. a fresh character, or one who hasn't used a trait manual yet). The pre-existing `if (extraTraits != null)` guard further down still applies to the rest of the method, but this new loop runs before it and crashes on `foreach` over `null`.

Reproduced on 0.9.16 with a modded-classes setup (theworkingclasses + rustboundmagic), but it doesn't depend on any other mod — any player with no extraTraits set hits this the first time they open the Traits tab.

## Fix

Wrap the new cleanup block in the same null check. No behavior change for players who do have extraTraits.

Tested by rebuilding against the 1.22.3 reference DLLs and confirming the character screen no longer throws for a player with an empty `extraTraits` attribute.